### PR TITLE
Sections add actionrow

### DIFF
--- a/src/app/(app)/course/[courseId]/students/(hooks)/useStudentSections.tsx
+++ b/src/app/(app)/course/[courseId]/students/(hooks)/useStudentSections.tsx
@@ -1,0 +1,28 @@
+import {createContext, useContext, useState, PropsWithChildren} from "react"
+
+// TODO: add functionality that calls update-sections endpoint (INTEGRATE BACKEND)
+type StudentRowContextType = {
+    isEditable: boolean;
+    setEditable: (editable: boolean) => void;
+}
+
+const defaultStudentRowState: StudentRowContextType = {
+  isEditable: false,
+  setEditable: ()  => {},
+}
+
+export const StudentRowContext = createContext<StudentRowContextType>(defaultStudentRowState)
+
+export const StudentRowProvider: React.FC<PropsWithChildren> = ({children}) => {
+  const [isEditable, setEditable] = useState<boolean>(false)
+
+  return(
+    <StudentRowContext.Provider value={{isEditable, setEditable}}>
+      {children}
+    </StudentRowContext.Provider>
+  )
+}
+
+export const useStudentRow = (): StudentRowContextType => {
+  return useContext(StudentRowContext)
+}

--- a/src/app/(app)/course/[courseId]/students/(table)/columns.tsx
+++ b/src/app/(app)/course/[courseId]/students/(table)/columns.tsx
@@ -1,12 +1,12 @@
 "use client"
 
+import { useStudentRow } from "../(hooks)/useStudentSections"
 import { Student } from "@/_temp_types/student"
-import { ColumnDef } from "@tanstack/react-table"
+import { Row, ColumnDef } from "@tanstack/react-table"
 import { Text } from "@/components/ui/text"
 import { Badge } from "@/components/ui/badge"
 import { DataTableColumnHeader } from "@/components/ui/table-column-header"
 import { MoreHorizontal } from "lucide-react"
-
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,102 +15,131 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 
-type SectionFilterValue = string[];
+import {StudentsSectionsSelect} from "./students-sections-select"
 
-export const columns: ColumnDef<Student>[] = [
-  {
-    id: "firstName",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title="First Name"
-        hasDropDownMenu={false}
-      />
-    ),
-    accessorFn: (row) => row.name.split(",")[1],
-    cell: ({ getValue }) => (
-      <Text element="p" as="smallText">
-        {String(getValue())}
-      </Text>
-    ),
-  },
-  {
-    id: "lastName",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title="Last Name"
-        hasDropDownMenu={false}
-      />
-    ),
-    accessorFn: (row) => row.name.split(",")[0],
-    cell: ({ getValue }) => (
-      <Text element="p" as="smallText">
-        {String(getValue())}
-      </Text>
-    ),
-  },
-  {
-    accessorKey: "id",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title="Student ID"
-        hasDropDownMenu={false}
-      />
-    ),
-    cell: ({ row }) => (
-      <Text element="p" as="smallText">
-        {row.getValue("id")}
-      </Text>
-    ),
-  },
-  {
-    accessorKey: "sections",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title="Sections"
-        hasDropDownMenu={false}
-      />
-    ),
-    cell: ({ row }) => (
+type SectionFilterValue = string[];
+type CellsNeedingContextType = {
+  row: Row<Student>;
+  columnId: string;
+}
+
+const CellsNeedingContext: React.FC<CellsNeedingContextType> = ({row, columnId}) => {
+  const { isEditable, setEditable } = useStudentRow()
+  if (columnId === 'sections') {
+    return (
       <div className="flex flex-row gap-2">
-        {/* TODO: convert this to use and render a fancy multiselect component */}
-        {(row.getValue("sections") as string[])?.map((section) => (
-          <Badge key={section} variant="secondary" className="rounded-sm">
-            <Text element="p" as="mutedText">
-              {section}
-            </Text>
-          </Badge>
-        ))}
+        {isEditable ?
+          <StudentsSectionsSelect studentSections={(row.getValue("sections") as string[]).map((section) => ({
+            label: section,
+            value: section,
+          }))} />
+          :
+          (row.getValue("sections") as string[]).map((section) => (
+            <Badge key={section} variant="secondary" className="rounded-sm">
+              <Text element="p" as="mutedText">
+                {section}
+              </Text>
+            </Badge>
+          ))
+        }
       </div>
-    ),
-    filterFn: (row, id, filterValues: SectionFilterValue) => {
-      const rowSections = row.getValue(id) as string[]
-      return filterValues.some((filterValue) =>
-        rowSections.includes(filterValue),)
-    },
-  },
-  {
-    id: "actions",
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title="Actions"
-        hasDropDownMenu={true}
-      />
-    ),
-    cell: ({ row }) => (
+    )
+  } else if (columnId === 'actions') {
+    return (
       <DropdownMenu>
         <DropdownMenuTrigger>
           <MoreHorizontal size={20} />
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuLabel>Actions</DropdownMenuLabel>
-          <DropdownMenuItem>Edit Sections</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setEditable(!isEditable)}>
+            {isEditable ? 'Confirm' : 'Edit'} Sections
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-    ),
+    )
+  }
+}
+
+
+export const columns: ColumnDef<Student>[] = [  {
+  id: "firstName",
+  header: ({ column }) => (
+    <DataTableColumnHeader
+      column={column}
+      title="First Name"
+      hasDropDownMenu={false}
+    />
+  ),
+  accessorFn: (row) => row.name.split(",")[1],
+  cell: ({ getValue }) => (
+    <Text element="p" as="smallText">
+      {String(getValue())}
+    </Text>
+  ),
+},
+{
+  id: "lastName",
+  header: ({ column }) => (
+    <DataTableColumnHeader
+      column={column}
+      title="Last Name"
+      hasDropDownMenu={false}
+    />
+  ),
+  accessorFn: (row) => row.name.split(",")[0],
+  cell: ({ getValue }) => (
+    <Text element="p" as="smallText">
+      {String(getValue())}
+    </Text>
+  ),
+},
+{
+  accessorKey: "id",
+  header: ({ column }) => (
+    <DataTableColumnHeader
+      column={column}
+      title="Student ID"
+      hasDropDownMenu={false}
+    />
+  ),
+  cell: ({ row }) => (
+    <Text element="p" as="smallText">
+      {row.getValue("id")}
+    </Text>
+  ),
+},
+{
+  accessorKey: "sections",
+  header: ({ column }) => (
+    <DataTableColumnHeader
+      column={column}
+      title="Sections"
+      hasDropDownMenu={false}
+    />
+  ),
+  cell: ({ row }) => (
+    <div className="flex flex-row gap-2">
+      <CellsNeedingContext row={row} columnId="sections" />
+    </div>
+  ),
+  filterFn: (row, id, filterValues: SectionFilterValue) => {
+    const rowSections = row.getValue(id) as string[]
+    return filterValues.some((filterValue) =>
+      rowSections.includes(filterValue),)
   },
+},
+{
+  id: "actions",
+  header: ({ column }) => (
+    <DataTableColumnHeader
+      column={column}
+      title="Actions"
+      hasDropDownMenu={true}
+    />
+  ),
+  cell: ({ row }) => (
+    <CellsNeedingContext row={row} columnId="actions" />
+  ),
+},
 ]

--- a/src/app/(app)/course/[courseId]/students/(table)/columns.tsx
+++ b/src/app/(app)/course/[courseId]/students/(table)/columns.tsx
@@ -5,6 +5,15 @@ import { ColumnDef } from "@tanstack/react-table"
 import { Text } from "@/components/ui/text"
 import { Badge } from "@/components/ui/badge"
 import { DataTableColumnHeader } from "@/components/ui/table-column-header"
+import { MoreHorizontal } from "lucide-react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 type SectionFilterValue = string[];
 
@@ -67,6 +76,7 @@ export const columns: ColumnDef<Student>[] = [
     ),
     cell: ({ row }) => (
       <div className="flex flex-row gap-2">
+        {/* TODO: convert this to use and render a fancy multiselect component */}
         {(row.getValue("sections") as string[])?.map((section) => (
           <Badge key={section} variant="secondary" className="rounded-sm">
             <Text element="p" as="mutedText">
@@ -81,5 +91,26 @@ export const columns: ColumnDef<Student>[] = [
       return filterValues.some((filterValue) =>
         rowSections.includes(filterValue),)
     },
+  },
+  {
+    id: "actions",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Actions"
+        hasDropDownMenu={true}
+      />
+    ),
+    cell: ({ row }) => (
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <MoreHorizontal size={20} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          <DropdownMenuItem>Edit Sections</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
   },
 ]

--- a/src/app/(app)/course/[courseId]/students/(table)/student-table.tsx
+++ b/src/app/(app)/course/[courseId]/students/(table)/student-table.tsx
@@ -29,6 +29,7 @@ import { DataTablePagination } from "@/components/ui/data-table-pagination"
 import { DataTableToolbar } from "../(table)/student-table-toolbar"
 import { useStudents } from "../(hooks)/useStudents"
 import { columns } from "../(table)/columns"
+import { StudentRowProvider, useStudentRow } from "../(hooks)/useStudentSections"
 
 type DataTableProps<TData, TValue> = {
   columns: ColumnDef<TData, TValue>[];
@@ -96,17 +97,18 @@ const DataTable = <TData, TValue>({
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell,
-                        cell.getContext(),)}
-                    </TableCell>
-                  ))}
-                </TableRow>
+                <StudentRowProvider key={row.id}>
+                  <TableRow
+                    data-state={row.getIsSelected() && "selected"}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell,
+                          cell.getContext(),)}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </StudentRowProvider>
               ))
             ) : (
               <TableRow>
@@ -128,5 +130,6 @@ const DataTable = <TData, TValue>({
 
 export const StudentTable = () => {
   const { displayStudents } = useStudents() ?? {}
+  const { isEditable, setEditable } = useStudentRow()
   return <DataTable data={displayStudents ?? []} columns={columns} />
 }

--- a/src/app/(app)/course/[courseId]/students/(table)/students-sections-select.tsx
+++ b/src/app/(app)/course/[courseId]/students/(table)/students-sections-select.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command"
+
+import { Command as CommandPrimitive } from "cmdk"
+import { useStudents } from "../(hooks)/useStudents"
+import { useRef, useState, useCallback, useEffect } from "react"
+
+type DropdownOption = {
+    label: string;
+    value: string;
+};
+type FancyMultiSelectProps = {
+    studentSections: DropdownOption[];
+}
+
+export function StudentsSectionsSelect( {studentSections} : FancyMultiSelectProps) {
+  const { allSections } = useStudents()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<DropdownOption[]>([])
+  const [inputValue, setInputValue] = useState("")
+
+  useEffect(() => {
+    setSelected(studentSections)
+  }, [studentSections])
+
+  const handleUnselect = useCallback((section: DropdownOption) => {
+    setSelected(prev => prev.filter(s => s.value !== section.value))
+  }, [])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const input = inputRef.current
+    if (input) {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (input.value === "") {
+          setSelected(prev => {
+            const newSelected = [...prev]
+            newSelected.pop()
+            return newSelected
+          })
+        }
+      }
+      // This is not a default behaviour of the <input /> field
+      if (e.key === "Escape") {
+        input.blur()
+      }
+    }
+  }, [])
+
+  const selectables = allSections?.filter(section => !selected.includes(section)) ?? []
+
+  return (
+    <Command onKeyDown={handleKeyDown} className="overflow-visible bg-transparent">
+      <div
+        className="group border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+      >
+        <div className="flex gap-1 flex-wrap">
+          {selected.map((section) => {
+            return (
+              <Badge key={section.value} variant="secondary">
+                {section.label}
+                <button
+                  className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleUnselect(section)
+                    }
+                  }}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                  }}
+                  onClick={() => handleUnselect(section)}
+                >
+                  <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                </button>
+              </Badge>
+            )
+          })}
+          {/* Avoid having the "Search" Icon */}
+          <CommandPrimitive.Input
+            ref={inputRef}
+            value={inputValue}
+            onValueChange={setInputValue}
+            onBlur={() => setOpen(false)}
+            onFocus={() => setOpen(true)}
+            placeholder="Select frameworks..."
+            className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1"
+          />
+        </div>
+      </div>
+      <div className="relative mt-2">
+        {open && selectables.length > 0 ?
+          <div className="absolute w-full z-10 top-0 rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
+            <CommandGroup className="h-full overflow-auto">
+              {selectables.map((section) => {
+                return (
+                  <CommandItem
+                    key={section.value}
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                    }}
+                    onSelect={(value) => {
+                      setInputValue("")
+                      setSelected(prev => [...prev, section])
+                    }}
+                    className={"cursor-pointer"}
+                  >
+                    {section.label}
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </div>
+          : null}
+      </div>
+    </Command >
+  )
+}


### PR DESCRIPTION
Progress made on Specs so far:

- Each row has a context that manages an `editable` state: this state is used to toggle between displaying the sections as badges or a multimodal select in sections column.
  - This state is currently toggled using a newly added action column.
- Still needs to be polished up UI wise.