### PR TITLE
Improve breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Project setup:
    - Use a good password, the signup will fail if the password is weak.
 4. Once signed up, you will be redirected to the course's onboarding dashboard.
 
+
 ### Useful commands
 
 Loading components from shadcn/ui

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -18,37 +18,38 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
   return (
     <main className="container flex-col min-h-screen pb-8">
       <div className="flex flex-col gap-3 pt-12 pb-4">
-        {breadcrumbs && (
-          <div className="flex gap-1">
-            {breadcrumbs.map((breadcrumb, index) => (
-              <div key={index} className="flex flex-row gap-1">
-                {breadcrumb.title === title ? (
+      {breadcrumbs && (
+        <div className="flex gap-1">
+          {breadcrumbs.map((breadcrumb, index) => (
+            <div key={index} className="flex flex-row gap-1">
+              {index === breadcrumbs.length - 1 ? (
+                <Text
+                  element="p"
+                  as={"smallText"}
+                  className="font-bold"
+                >
+                  {breadcrumb.title}
+                </Text>
+              ) : (
+                <Link href={breadcrumb.href} className="hover:underline">
                   <Text
                     element="p"
                     as={"smallText"}
-                    className="font-bold"
                   >
                     {breadcrumb.title}
                   </Text>
-                ) : (
-                  <Link href={breadcrumb.href} className="hover:underline">
-                    <Text
-                      element="p"
-                      as={"smallText"}
-                    >
-                      {breadcrumb.title}
-                    </Text>
-                  </Link>
-                )}
-                {index < breadcrumbs.length - 1 && (
-                  <Text element="p" as={"smallText"}>
-                    &gt;
-                  </Text>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+                </Link>
+              )}
+              {index < breadcrumbs.length - 1 && (
+                <Text element="p" as={"smallText"}>
+                  &gt;
+                </Text>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
         <div className="flex justify-between">
           <Text
             element={"h1"}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -31,7 +31,7 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                     {breadcrumb.title}
                   </Text>
                 ) : (
-                  <Link href={breadcrumb.href} className="hover:underline cursor-pointer">
+                  <Link href={breadcrumb.href} className="hover:underline">
                     <Text
                       element="p"
                       as={"smallText"}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -31,11 +31,10 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                     {breadcrumb.title}
                   </Text>
                 ) : (
-                  <Link href={breadcrumb.href}>
+                  <Link href={breadcrumb.href} className="hover:underline cursor-pointer">
                     <Text
                       element="p"
                       as={"smallText"}
-                      className="hover:underline cursor-pointer"
                     >
                       {breadcrumb.title}
                     </Text>

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -49,7 +49,6 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
             ))}
           </div>
         )}
-
         <div className="flex justify-between">
           <Text
             element={"h1"}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -18,37 +18,37 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
   return (
     <main className="container flex-col min-h-screen pb-8">
       <div className="flex flex-col gap-3 pt-12 pb-4">
-      {breadcrumbs && (
-        <div className="flex gap-1">
-          {breadcrumbs.map((breadcrumb, index) => (
-            <div key={index} className="flex flex-row gap-1">
-              {index === breadcrumbs.length - 1 ? (
-                <Text
-                  element="p"
-                  as={"smallText"}
-                  className="font-bold"
-                >
-                  {breadcrumb.title}
-                </Text>
-              ) : (
-                <Link href={breadcrumb.href} className="hover:underline">
+        {breadcrumbs && (
+          <div className="flex gap-1">
+            {breadcrumbs.map((breadcrumb, index) => (
+              <div key={index} className="flex flex-row gap-1">
+                {index === breadcrumbs.length - 1 ? (
                   <Text
                     element="p"
                     as={"smallText"}
+                    className="font-bold"
                   >
                     {breadcrumb.title}
                   </Text>
-                </Link>
-              )}
-              {index < breadcrumbs.length - 1 && (
-                <Text element="p" as={"smallText"}>
-                  &gt;
-                </Text>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+                ) : (
+                  <Link href={breadcrumb.href} className="hover:underline">
+                    <Text
+                      element="p"
+                      as={"smallText"}
+                    >
+                      {breadcrumb.title}
+                    </Text>
+                  </Link>
+                )}
+                {index < breadcrumbs.length - 1 && (
+                  <Text element="p" as={"smallText"}>
+                    &gt;
+                  </Text>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
 
         <div className="flex justify-between">
           <Text

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -1,7 +1,7 @@
-import { Text } from "@/components/ui/text"
-import Link from "next/link"
-import { Action } from "@/types"
 import { Button } from "@/components/ui/button"
+import { Text } from "@/components/ui/text"
+import { Action } from "@/types"
+import Link from "next/link"
 import React from "react"
 
 type PageViewProps = {
@@ -22,14 +22,30 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
           <div className="flex gap-1">
             {breadcrumbs.map((breadcrumb, index) => (
               <div key={index} className="flex flex-row gap-1">
-                <Link href={breadcrumb.href}>
-                  <Text element="p" as={"smallText"}>
+                {breadcrumb.title === title ? (
+                  <Text
+                    element="p"
+                    as={"smallText"}
+                    className="font-bold"
+                  >
                     {breadcrumb.title}
                   </Text>
-                </Link>
-                <Text element="p" as={"smallText"}>
-                  /
-                </Text>
+                ) : (
+                  <Link href={breadcrumb.href}>
+                    <Text
+                      element="p"
+                      as={"smallText"}
+                      className="hover:underline cursor-pointer"
+                    >
+                      {breadcrumb.title}
+                    </Text>
+                  </Link>
+                )}
+                {index < breadcrumbs.length - 1 && (
+                  <Text element="p" as={"smallText"}>
+                    &gt;
+                  </Text>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
### Changes made in this PR:
- The bread crumb which represent the current page is bold and un-clickable
- Any bread crumb that doesn't represent the first page is underlined when hovered over.
- Each bread crumb is followed by a ">" with exception for the last bread crumb which represents the current page

The format of the bread crumbs are now as such: home > **Students**