### PR TITLE
Action menu added for mobile

### DIFF
--- a/src/app/(app)/course/[courseId]/setup/(hooks)/useSetupSteps.tsx
+++ b/src/app/(app)/course/[courseId]/setup/(hooks)/useSetupSteps.tsx
@@ -1,13 +1,13 @@
-import React, { ReactNode, useState } from "react"
 import { OnboardingProgress } from "@/_temp_types/onboarding"
-import { Action, NonEmptyArray } from "@/types"
-import { StepDefinition } from "@/app/(app)/course/[courseId]/setup/(components)/SetupStepDetailCard"
-import { useImportStudentsFromLms } from "@/hooks/use-import-students-from-lms"
-import { useImportStudentGradebookData } from "@/hooks/use-import-student-gradebook-data"
-import { GenerateOptInQuiz } from "@/app/(app)/course/[courseId]/setup/(components)/GenerateOptInQuiz"
-import { useOnboardingProgress } from "@/hooks/use-onboarding-progress"
-import { useGenerateTeams } from "@/hooks/use-generate-teams"
 import { GenerateTeamsAttributeSelector } from "@/app/(app)/course/[courseId]/components/GenerateTeamsAttributeSelector"
+import { GenerateOptInQuiz } from "@/app/(app)/course/[courseId]/setup/(components)/GenerateOptInQuiz"
+import { StepDefinition } from "@/app/(app)/course/[courseId]/setup/(components)/SetupStepDetailCard"
+import { useGenerateTeams } from "@/hooks/use-generate-teams"
+import { useImportStudentGradebookData } from "@/hooks/use-import-student-gradebook-data"
+import { useImportStudentsFromLms } from "@/hooks/use-import-students-from-lms"
+import { useOnboardingProgress } from "@/hooks/use-onboarding-progress"
+import { Action, NonEmptyArray } from "@/types"
+import { ReactNode, useState } from "react"
 
 interface UseSetupStepsReturnType {
   steps: NonEmptyArray<StepDefinition>;
@@ -20,11 +20,11 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
   const { data, isLoading, refetch } = useOnboardingProgress()
 
   const {
-    importStudentsFromLmsAsync,
+    importStudentsWithToast,
     isPending: importStudentsFromLmsPending,
   } = useImportStudentsFromLms()
   const {
-    importStudentGradebookDataAsync,
+    importGradebookDataWithToast,
     isPending: importStudentGradebookDataPending,
   } = useImportStudentGradebookData()
   const { generateTeamsAsync, isPending: generateTeamsPending } =
@@ -48,7 +48,7 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
     IMPORT_STUDENTS: {
       content: "Import students",
       onClick: async () => {
-        await importStudentsFromLmsAsync(undefined)
+        await importStudentsWithToast()
         await refetch()
       },
       loading: importStudentsFromLmsPending,
@@ -56,7 +56,7 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
     STUDENT_DATA: {
       content: "Import gradebook data",
       onClick: async () => {
-        await importStudentGradebookDataAsync(undefined)
+        await importGradebookDataWithToast()
         await refetch()
       },
       loading: importStudentGradebookDataPending,

--- a/src/app/(app)/course/[courseId]/setup/(hooks)/useSetupSteps.tsx
+++ b/src/app/(app)/course/[courseId]/setup/(hooks)/useSetupSteps.tsx
@@ -20,11 +20,11 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
   const { data, isLoading, refetch } = useOnboardingProgress()
 
   const {
-    importStudentsWithToast,
+    importStudentsAsync,
     isPending: importStudentsFromLmsPending,
   } = useImportStudentsFromLms()
   const {
-    importGradebookDataWithToast,
+    importGradebookDataAsync,
     isPending: importStudentGradebookDataPending,
   } = useImportStudentGradebookData()
   const { generateTeamsAsync, isPending: generateTeamsPending } =
@@ -48,7 +48,7 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
     IMPORT_STUDENTS: {
       content: "Import students",
       onClick: async () => {
-        await importStudentsWithToast()
+        await importStudentsAsync()
         await refetch()
       },
       loading: importStudentsFromLmsPending,
@@ -56,7 +56,7 @@ export const useSetupSteps = (): UseSetupStepsReturnType => {
     STUDENT_DATA: {
       content: "Import gradebook data",
       onClick: async () => {
-        await importGradebookDataWithToast()
+        await importGradebookDataAsync()
         await refetch()
       },
       loading: importStudentGradebookDataPending,

--- a/src/app/(app)/course/[courseId]/students/page.tsx
+++ b/src/app/(app)/course/[courseId]/students/page.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import React from "react"
-import { StudentsProvider, useStudents } from "./(hooks)/useStudents"
 import PageView from "@/components/views/Page"
-import { StudentTable } from "./(table)/student-table"
-import { useImportStudentsFromLms } from "@/hooks/use-import-students-from-lms"
 import { useImportStudentGradebookData } from "@/hooks/use-import-student-gradebook-data"
+import { useImportStudentsFromLms } from "@/hooks/use-import-students-from-lms"
+import { StudentsProvider, useStudents } from "./(hooks)/useStudents"
+import { StudentTable } from "./(table)/student-table"
 
 export default function StudentsPage() {
   return (
@@ -17,15 +16,17 @@ export default function StudentsPage() {
 
 const StudentsPageView = () => {
   const { refetch } = useStudents()
+
   const {
-    importStudentsFromLmsAsync,
+    importStudentsWithToast,
     isPending: importStudentsFromLmsPending,
   } = useImportStudentsFromLms()
 
   const {
-    importStudentGradebookDataAsync,
+    importGradebookDataWithToast,
     isPending: importStudentGradebookDataPending,
   } = useImportStudentGradebookData()
+
 
   return (
     <PageView
@@ -38,7 +39,7 @@ const StudentsPageView = () => {
         {
           content: "Import students",
           onClick: async () => {
-            await importStudentsFromLmsAsync(undefined)
+            await importStudentsWithToast()
             await refetch()
           },
           loading: importStudentsFromLmsPending,
@@ -46,7 +47,7 @@ const StudentsPageView = () => {
         {
           content: "Import gradebook data",
           onClick: async () => {
-            await importStudentGradebookDataAsync(undefined)
+            await importGradebookDataWithToast()
             await refetch()
           },
           loading: importStudentGradebookDataPending,

--- a/src/app/(app)/course/[courseId]/students/page.tsx
+++ b/src/app/(app)/course/[courseId]/students/page.tsx
@@ -18,12 +18,12 @@ const StudentsPageView = () => {
   const { refetch } = useStudents()
 
   const {
-    importStudentsWithToast,
+    importStudentsAsync,
     isPending: importStudentsFromLmsPending,
   } = useImportStudentsFromLms()
 
   const {
-    importGradebookDataWithToast,
+    importGradebookDataAsync,
     isPending: importStudentGradebookDataPending,
   } = useImportStudentGradebookData()
 
@@ -39,7 +39,7 @@ const StudentsPageView = () => {
         {
           content: "Import students",
           onClick: async () => {
-            await importStudentsWithToast()
+            await importStudentsAsync()
             await refetch()
           },
           loading: importStudentsFromLmsPending,
@@ -47,7 +47,7 @@ const StudentsPageView = () => {
         {
           content: "Import gradebook data",
           onClick: async () => {
-            await importGradebookDataWithToast()
+            await importGradebookDataAsync()
             await refetch()
           },
           loading: importStudentGradebookDataPending,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,14 +5,12 @@ import { useAuthUser } from "@/app/(providers)/auth-user-provider"
 import Logo from "@/components/Logo"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+  DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import {
   NavigationMenu,
@@ -51,7 +49,7 @@ const Navbar = () => {
               <HamburgerMenuIcon className="w-6 h-6"/>
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="flex flex-col gap-4">
+          <DropdownMenuContent className="flex flex-col">
             <DropdownMenuLabel className="flex justify-center">
               {authUser ? (
                 <Avatar>
@@ -65,7 +63,6 @@ const Navbar = () => {
                 </Avatar>
               )}
             </DropdownMenuLabel>
-            <DropdownMenuSeparator />
             <NavigationMenuLink
               href={`/course/${courseId}/setup`}
               className={navigationMenuTriggerStyle()}
@@ -84,14 +81,8 @@ const Navbar = () => {
             >
                   Manage Teams
             </NavigationMenuLink>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="flex justify-center">
-              <Button
-                variant="outline"
-                onClick={logoutSync}
-              >
-                      Logout
-              </Button>
+            <DropdownMenuItem className={navigationMenuTriggerStyle()}>
+              Logout
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,8 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
   NavigationMenu,
@@ -50,19 +49,6 @@ const Navbar = () => {
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent className="flex flex-col">
-            <DropdownMenuLabel className="flex justify-center">
-              {authUser ? (
-                <Avatar>
-                  <AvatarFallback>
-                    {authUser.username[0].toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-              ) : (
-                <Avatar className="animate-pulse">
-                  <AvatarFallback></AvatarFallback>
-                </Avatar>
-              )}
-            </DropdownMenuLabel>
             <NavigationMenuLink
               href={`/course/${courseId}/setup`}
               className={navigationMenuTriggerStyle()}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -41,12 +42,7 @@ const Navbar = () => {
       <div className="flex md:hidden">
         <DropdownMenu>
           <DropdownMenuTrigger>
-            <button
-              aria-label="Toggle navigation"
-              className="focus:outline-none"
-            >
-              <HamburgerMenuIcon className="w-6 h-6"/>
-            </button>
+            <HamburgerMenuIcon className="w-6 h-6"/>
           </DropdownMenuTrigger>
           <DropdownMenuContent className="flex flex-col">
             <NavigationMenuLink
@@ -67,7 +63,11 @@ const Navbar = () => {
             >
                   Manage Teams
             </NavigationMenuLink>
-            <DropdownMenuItem className={navigationMenuTriggerStyle()}>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={logoutSync}
+              className={navigationMenuTriggerStyle()}
+            >
               Logout
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -21,16 +23,13 @@ import {
 } from "@/components/ui/navigation-menu"
 import { Text } from "@/components/ui/text"
 import { useLogout } from "@/hooks/use-logout"
-import { Cross1Icon, HamburgerMenuIcon } from "@radix-ui/react-icons"
+import { HamburgerMenuIcon } from "@radix-ui/react-icons"
 import Link from "next/link"
-import { useState } from 'react'
 
 const Navbar = () => {
   const { authUser } = useAuthUser()
   const { logoutSync } = useLogout()
   const { courseId, courseName } = useCourse()
-  const [menuOpen, setMenuOpen] = useState(false)
-  const toggleMenu = () => setMenuOpen(!menuOpen)
 
   return (
     <NavigationMenu className="container my-4 mx-0 min-w-full flex justify-between gap-4 sticky">
@@ -44,55 +43,58 @@ const Navbar = () => {
 
       <div className="flex md:hidden">
         <DropdownMenu>
-            <DropdownMenuTrigger>
-              <button
-                onClick={toggleMenu}
-                aria-label="Toggle navigation"
-                className="focus:outline-none"
-              >
-                {menuOpen ? <Cross1Icon className="w-6 h-6" /> : <HamburgerMenuIcon className="w-6 h-6" />}
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="flex flex-col items-center gap-4">
-                <NavigationMenuLink
-                  href={`/course/${courseId}/setup`}
-                  className={navigationMenuTriggerStyle()}
-                >
+          <DropdownMenuTrigger>
+            <button
+              aria-label="Toggle navigation"
+              className="focus:outline-none"
+            >
+              <HamburgerMenuIcon className="w-6 h-6"/>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="flex flex-col gap-4">
+            <DropdownMenuLabel className="flex justify-center">
+              {authUser ? (
+                <Avatar>
+                  <AvatarFallback>
+                    {authUser.username[0].toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+              ) : (
+                <Avatar className="animate-pulse">
+                  <AvatarFallback></AvatarFallback>
+                </Avatar>
+              )}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <NavigationMenuLink
+              href={`/course/${courseId}/setup`}
+              className={navigationMenuTriggerStyle()}
+            >
                   Onboarding
-                </NavigationMenuLink>
-                <NavigationMenuLink
-                  href={`/course/${courseId}/team-sets`}
-                  className={navigationMenuTriggerStyle()}
-                >
+            </NavigationMenuLink>
+            <NavigationMenuLink
+              href={`/course/${courseId}/students`}
+              className={navigationMenuTriggerStyle()}
+            >
+                  Students
+            </NavigationMenuLink>
+            <NavigationMenuLink
+              href={`/course/${courseId}/team-sets`}
+              className={navigationMenuTriggerStyle()}
+            >
                   Manage Teams
-                </NavigationMenuLink>
-                <NavigationMenuLink
-                  href={`/course/${courseId}/team-sets`}
-                  className={navigationMenuTriggerStyle()}
-                >
-                  Manage Teams
-                </NavigationMenuLink>
-                <DropdownMenuItem className="gap-2">
-                    {authUser ? (
-                      <Avatar>
-                        <AvatarFallback>
-                          {authUser.username[0].toUpperCase()}
-                        </AvatarFallback>
-                      </Avatar>
-                    ) : (
-                      <Avatar className="animate-pulse">
-                        <AvatarFallback></AvatarFallback>
-                      </Avatar>
-                    )}
-                    <Button 
-                      variant="outline"
-                      onClick={logoutSync}
-                    >
+            </NavigationMenuLink>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="flex justify-center">
+              <Button
+                variant="outline"
+                onClick={logoutSync}
+              >
                       Logout
-                    </Button>
-                </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              </Button>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       <div className="flex gap-2 hidden md:flex">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,17 @@
 "use client"
 
+import { useCourse } from "@/app/(app)/course/[courseId]/(hooks)/useCourse"
+import { useAuthUser } from "@/app/(providers)/auth-user-provider"
+import Logo from "@/components/Logo"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -8,25 +20,17 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu"
 import { Text } from "@/components/ui/text"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { useAuthUser } from "@/app/(providers)/auth-user-provider"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { useLogout } from "@/hooks/use-logout"
-import { useParams } from "next/navigation"
-import { useCourse } from "@/app/(app)/course/[courseId]/(hooks)/useCourse"
-import Logo from "@/components/Logo"
+import { Cross1Icon, HamburgerMenuIcon } from "@radix-ui/react-icons"
 import Link from "next/link"
-import { Badge } from "@/components/ui/badge"
+import { useState } from 'react'
 
 const Navbar = () => {
   const { authUser } = useAuthUser()
   const { logoutSync } = useLogout()
   const { courseId, courseName } = useCourse()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const toggleMenu = () => setMenuOpen(!menuOpen)
 
   return (
     <NavigationMenu className="container my-4 mx-0 min-w-full flex justify-between gap-4 sticky">
@@ -37,7 +41,61 @@ const Navbar = () => {
         <Text element="p">|</Text>
         <Badge variant="outline">{courseName}</Badge>
       </div>
-      <div className="flex gap-2">
+
+      <div className="flex md:hidden">
+        <DropdownMenu>
+            <DropdownMenuTrigger>
+              <button
+                onClick={toggleMenu}
+                aria-label="Toggle navigation"
+                className="focus:outline-none"
+              >
+                {menuOpen ? <Cross1Icon className="w-6 h-6" /> : <HamburgerMenuIcon className="w-6 h-6" />}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="flex flex-col items-center gap-4">
+                <NavigationMenuLink
+                  href={`/course/${courseId}/setup`}
+                  className={navigationMenuTriggerStyle()}
+                >
+                  Onboarding
+                </NavigationMenuLink>
+                <NavigationMenuLink
+                  href={`/course/${courseId}/team-sets`}
+                  className={navigationMenuTriggerStyle()}
+                >
+                  Manage Teams
+                </NavigationMenuLink>
+                <NavigationMenuLink
+                  href={`/course/${courseId}/team-sets`}
+                  className={navigationMenuTriggerStyle()}
+                >
+                  Manage Teams
+                </NavigationMenuLink>
+                <DropdownMenuItem className="gap-2">
+                    {authUser ? (
+                      <Avatar>
+                        <AvatarFallback>
+                          {authUser.username[0].toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                    ) : (
+                      <Avatar className="animate-pulse">
+                        <AvatarFallback></AvatarFallback>
+                      </Avatar>
+                    )}
+                    <Button 
+                      variant="outline"
+                      onClick={logoutSync}
+                    >
+                      Logout
+                    </Button>
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+      </div>
+
+      <div className="flex gap-2 hidden md:flex">
         <NavigationMenuList className="flex justify-between">
           <NavigationMenuItem>
             <NavigationMenuLink

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -1,17 +1,17 @@
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu";
-import { Text } from "@/components/ui/text";
-import { Action } from "@/types";
-import { UploadIcon } from "@radix-ui/react-icons";
-import Link from "next/link";
-import React, { useEffect, useState } from "react";
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Text } from "@/components/ui/text"
+import { Action } from "@/types"
+import { UploadIcon } from "@radix-ui/react-icons"
+import Link from "next/link"
+import React, { useEffect, useState } from "react"
 
 
 
@@ -86,31 +86,36 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
           </Text>
           {actions && (
             <div className="flex gap-3">
-              {isMobile ?(
+              {isMobile ? (
                 <div className="relative">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="outline">
-                        Import...
+                      <Button variant="outline" className="gap-2">
+                        Import data
+                        <UploadIcon/>
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent
-                    side="bottom" 
-                    align="end"
-                    className="absolute right-0 z-50 min-w-[200px]"
+                      side="bottom"
+                      align="end"
+                      className="absolute right-0 z-50 min-w-[200px]"
                     >
-                      <DropdownMenuLabel>Import Data</DropdownMenuLabel>
+                      <DropdownMenuLabel>Data import options</DropdownMenuLabel>
                       <DropdownMenuSeparator />
                       {actions.map((action, index) => (
-                        <DropdownMenuItem key={`action-${index}`} onClick={action.onClick}>
-                          <UploadIcon style={{ marginRight: '8px' }}/>
+                        <DropdownMenuItem
+                          key={`action-${index}`}
+                          onClick={action.onClick}
+                          className="gap-2"
+                        >
+                          <UploadIcon/>
                           {action.content}
                         </DropdownMenuItem>
                       ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
-              ):(
+              ) : (
                 actions.map((action, index) => (
                   <Button
                     key={`action-${index}`}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -96,8 +96,8 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent
                     side="bottom" 
-                    align="start"
-                    className="absolute z-50 min-w-[200px]"
+                    align="end"
+                    className="absolute right-0 z-50 min-w-[200px]"
                     >
                       <DropdownMenuLabel>Import Data</DropdownMenuLabel>
                       <DropdownMenuSeparator />

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Text } from "@/components/ui/text"
 import { Action } from "@/types"
-import { DotsVerticalIcon, UploadIcon } from "@radix-ui/react-icons"
+import { DotsVerticalIcon } from "@radix-ui/react-icons"
 import Link from "next/link"
 import React from "react"
 
@@ -22,6 +22,8 @@ type PageViewProps = {
   }>;
   actions?: Array<Action>;
 };
+
+
 
 const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
   return (
@@ -71,9 +73,12 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
               <div className="md:hidden relative">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <div className="inline-flex items-center justify-center whitespace-nowrap rounded-md focus-visible:outline-none border h-8 w-8 p-0">
+                    <Button
+                      className="inline-flex items-center justify-center whitespace-nowrap rounded-md focus-visible:outline-none border h-8 w-8 p-0"
+                      variant="ghost"
+                    >
                       <DotsVerticalIcon/>
-                    </div>
+                    </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent
                     side="bottom"
@@ -81,18 +86,22 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                     className="absolute right-0 z-50 min-w-[200px] space-y-3"
                   >
                     {actions.map((action, index) => (
-                      <DropdownMenuItem
-                        key={`action-${index}`}
-                        onClick={action.onClick}
-                        className="gap-2"
-                      >
-                        {action.content}
+                      <DropdownMenuItem key={`action-${index}`}>
+                        <Button
+                          onClick={action.onClick}
+                          loading={action.loading}
+                          variant="ghost"
+                          size="sm"
+                          className="gap-0"
+                        >
+                          {action.content}
+                        </Button>
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <div className="hidden md:flex gap-3 ">
+              <div className="hidden md:flex gap-1 ">
                 {actions.map((action, index) => (
                   <Button
                     key={`action-${index}`}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Text } from "@/components/ui/text"
 import { Action } from "@/types"
-import { UploadIcon } from "@radix-ui/react-icons"
+import { DotsVerticalIcon, UploadIcon } from "@radix-ui/react-icons"
 import Link from "next/link"
 import React from "react"
 
@@ -71,10 +71,9 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
               <div className="md:hidden relative">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button className="gap-2">
-                      Import data
-                      <UploadIcon/>
-                    </Button>
+                    <button className="inline-flex items-center justify-center whitespace-nowrap rounded-md focus-visible:outline-none border h-8 w-8 p-0">
+                      <DotsVerticalIcon/>
+                    </button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent
                     side="bottom"
@@ -94,7 +93,7 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <div className="hidden md:flex gap-3">
+              <div className="hidden md:flex gap-3 ">
                 {actions.map((action, index) => (
                   <Button
                     key={`action-${index}`}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -1,8 +1,15 @@
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu"
 import { Text } from "@/components/ui/text"
 import { Action } from "@/types"
 import Link from "next/link"
-import React from "react"
+import React, { useEffect, useState } from "react"
+
 
 type PageViewProps = {
   children: React.ReactNode;
@@ -15,6 +22,22 @@ type PageViewProps = {
 };
 
 const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
+
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768)
+    }
+
+    handleResize()
+
+    window.addEventListener("resize", handleResize)
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
   return (
     <main className="container flex-col min-h-screen pb-8">
       <div className="flex flex-col gap-3 pt-12 pb-4">
@@ -59,16 +82,29 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
           </Text>
           {actions && (
             <div className="flex gap-3">
-              {actions.map((action, index) => (
-                <Button
-                  key={`action-${index}`}
-                  onClick={action.onClick}
-                  loading={action.loading}
-                  size="sm"
-                >
-                  {action.content}
-                </Button>
-              ))}
+              {isMobile ?(
+                <DropdownMenu>
+                <DropdownMenuTrigger>Import data...</DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  {actions.map((action, index) => (
+                    <DropdownMenuItem key={`action-${index}`} onClick={action.onClick}>
+                        {action.content}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              ):(
+                actions.map((action, index) => (
+                  <Button
+                    key={`action-${index}`}
+                    onClick={action.onClick}
+                    loading={action.loading}
+                    size="sm"
+                  >
+                    {action.content}
+                  </Button>
+                ))
+              )}
             </div>
           )}
         </div>

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -71,9 +71,9 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
               <div className="md:hidden relative">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <button className="inline-flex items-center justify-center whitespace-nowrap rounded-md focus-visible:outline-none border h-8 w-8 p-0">
+                    <div className="inline-flex items-center justify-center whitespace-nowrap rounded-md focus-visible:outline-none border h-8 w-8 p-0">
                       <DotsVerticalIcon/>
-                    </button>
+                    </div>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent
                     side="bottom"
@@ -86,7 +86,6 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                         onClick={action.onClick}
                         className="gap-2"
                       >
-                        <UploadIcon/>
                         {action.content}
                       </DropdownMenuItem>
                     ))}

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -1,14 +1,18 @@
-import { Button } from "@/components/ui/button"
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu"
-import { Text } from "@/components/ui/text"
-import { Action } from "@/types"
-import Link from "next/link"
-import React, { useEffect, useState } from "react"
+} from "@/components/ui/dropdown-menu";
+import { Text } from "@/components/ui/text";
+import { Action } from "@/types";
+import { UploadIcon } from "@radix-ui/react-icons";
+import Link from "next/link";
+import React, { useEffect, useState } from "react";
+
 
 
 type PageViewProps = {
@@ -83,16 +87,29 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
           {actions && (
             <div className="flex gap-3">
               {isMobile ?(
-                <DropdownMenu>
-                <DropdownMenuTrigger>Import data...</DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  {actions.map((action, index) => (
-                    <DropdownMenuItem key={`action-${index}`} onClick={action.onClick}>
-                        {action.content}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                <div className="relative">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline">
+                        Import...
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                    side="bottom" 
+                    align="start"
+                    className="absolute z-50 min-w-[200px]"
+                    >
+                      <DropdownMenuLabel>Import Data</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      {actions.map((action, index) => (
+                        <DropdownMenuItem key={`action-${index}`} onClick={action.onClick}>
+                          <UploadIcon style={{ marginRight: '8px' }}/>
+                          {action.content}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               ):(
                 actions.map((action, index) => (
                   <Button

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -11,7 +11,7 @@ import { Text } from "@/components/ui/text"
 import { Action } from "@/types"
 import { UploadIcon } from "@radix-ui/react-icons"
 import Link from "next/link"
-import React, { useEffect, useState } from "react"
+import React from "react"
 
 
 
@@ -26,22 +26,6 @@ type PageViewProps = {
 };
 
 const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
-
-  const [isMobile, setIsMobile] = useState(false)
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < 768)
-    }
-
-    handleResize()
-
-    window.addEventListener("resize", handleResize)
-
-    return () => {
-      window.removeEventListener("resize", handleResize)
-    }
-  }, [])
   return (
     <main className="container flex-col min-h-screen pb-8">
       <div className="flex flex-col gap-3 pt-12 pb-4">
@@ -86,37 +70,36 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
           </Text>
           {actions && (
             <div className="flex gap-3">
-              {isMobile ? (
-                <div className="relative">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" className="gap-2">
-                        Import data
+              <div className="md:hidden relative">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" className="gap-2">
+                      Import data
+                      <UploadIcon/>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    side="bottom"
+                    align="end"
+                    className="absolute right-0 z-50 min-w-[200px]"
+                  >
+                    <DropdownMenuLabel>Data import options</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {actions.map((action, index) => (
+                      <DropdownMenuItem
+                        key={`action-${index}`}
+                        onClick={action.onClick}
+                        className="gap-2"
+                      >
                         <UploadIcon/>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      side="bottom"
-                      align="end"
-                      className="absolute right-0 z-50 min-w-[200px]"
-                    >
-                      <DropdownMenuLabel>Data import options</DropdownMenuLabel>
-                      <DropdownMenuSeparator />
-                      {actions.map((action, index) => (
-                        <DropdownMenuItem
-                          key={`action-${index}`}
-                          onClick={action.onClick}
-                          className="gap-2"
-                        >
-                          <UploadIcon/>
-                          {action.content}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              ) : (
-                actions.map((action, index) => (
+                        {action.content}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              <div className="hidden md:flex">
+                {actions.map((action, index) => (
                   <Button
                     key={`action-${index}`}
                     onClick={action.onClick}
@@ -125,8 +108,8 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                   >
                     {action.content}
                   </Button>
-                ))
-              )}
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/views/Page.tsx
+++ b/src/components/views/Page.tsx
@@ -3,8 +3,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Text } from "@/components/ui/text"
@@ -73,7 +71,7 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
               <div className="md:hidden relative">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="outline" className="gap-2">
+                    <Button className="gap-2">
                       Import data
                       <UploadIcon/>
                     </Button>
@@ -81,10 +79,8 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                   <DropdownMenuContent
                     side="bottom"
                     align="end"
-                    className="absolute right-0 z-50 min-w-[200px]"
+                    className="absolute right-0 z-50 min-w-[200px] space-y-3"
                   >
-                    <DropdownMenuLabel>Data import options</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
                     {actions.map((action, index) => (
                       <DropdownMenuItem
                         key={`action-${index}`}
@@ -98,7 +94,7 @@ const PageView = ({ children, title, breadcrumbs, actions }: PageViewProps) => {
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <div className="hidden md:flex">
+              <div className="hidden md:flex gap-3">
                 {actions.map((action, index) => (
                   <Button
                     key={`action-${index}`}

--- a/src/hooks/use-import-student-gradebook-data.ts
+++ b/src/hooks/use-import-student-gradebook-data.ts
@@ -1,7 +1,7 @@
-import { useToast } from "@/hooks/use-toast"
-import { useMutation } from "@tanstack/react-query"
 import { useCourse } from "@/app/(app)/course/[courseId]/(hooks)/useCourse"
 import { defaultMutationFn } from "@/app/(providers)/query-client-provider"
+import { useToast } from "@/hooks/use-toast"
+import { useMutation } from "@tanstack/react-query"
 
 export const useImportStudentGradebookData = () => {
   const { toast } = useToast()
@@ -31,8 +31,16 @@ export const useImportStudentGradebookData = () => {
     },
   })
 
+  const importGradebookDataWithToast = async() => {
+    toast({
+      title: "Importing student gradebook data",
+      description: "Please wait while we import student gradebook data from your LMS.",
+    })
+    await mutation.mutateAsync()
+  }
+
   return {
-    importStudentGradebookDataAsync: mutation.mutateAsync,
+    importGradebookDataWithToast,
     ...mutation,
   }
 }

--- a/src/hooks/use-import-student-gradebook-data.ts
+++ b/src/hooks/use-import-student-gradebook-data.ts
@@ -6,6 +6,15 @@ import { useMutation } from "@tanstack/react-query"
 export const useImportStudentGradebookData = () => {
   const { toast } = useToast()
   const { courseId } = useCourse()
+
+  const importGradebookDataAsync = async() => {
+    toast({
+      title: "Importing student gradebook data",
+      description: "Please wait while we import student gradebook data from your LMS.",
+    })
+    await mutation.mutateAsync()
+  }
+
   const mutation = useMutation<void, unknown, void>({
     mutationFn: async () => {
       return defaultMutationFn(
@@ -31,16 +40,8 @@ export const useImportStudentGradebookData = () => {
     },
   })
 
-  const importGradebookDataWithToast = async() => {
-    toast({
-      title: "Importing student gradebook data",
-      description: "Please wait while we import student gradebook data from your LMS.",
-    })
-    await mutation.mutateAsync()
-  }
-
   return {
-    importGradebookDataWithToast,
+    importGradebookDataAsync,
     ...mutation,
   }
 }

--- a/src/hooks/use-import-students-from-lms.ts
+++ b/src/hooks/use-import-students-from-lms.ts
@@ -1,7 +1,7 @@
-import { useToast } from "@/hooks/use-toast"
-import { useMutation } from "@tanstack/react-query"
 import { useCourse } from "@/app/(app)/course/[courseId]/(hooks)/useCourse"
 import { defaultMutationFn } from "@/app/(providers)/query-client-provider"
+import { useToast } from "@/hooks/use-toast"
+import { useMutation } from "@tanstack/react-query"
 
 export const useImportStudentsFromLms = () => {
   const { toast } = useToast()
@@ -27,8 +27,17 @@ export const useImportStudentsFromLms = () => {
     },
   })
 
+  const importStudentsWithToast = async () => {
+    toast({
+      title: "Importing students",
+      description: "Please wait while we import students from your LMS.",
+    })
+    await mutation.mutateAsync()
+  }
+
+
   return {
-    importStudentsFromLmsAsync: mutation.mutateAsync,
+    importStudentsWithToast,
     ...mutation,
   }
 }

--- a/src/hooks/use-import-students-from-lms.ts
+++ b/src/hooks/use-import-students-from-lms.ts
@@ -6,6 +6,15 @@ import { useMutation } from "@tanstack/react-query"
 export const useImportStudentsFromLms = () => {
   const { toast } = useToast()
   const { courseId } = useCourse()
+
+  const importStudentsAsync = async () => {
+    toast({
+      title: "Importing students",
+      description: "Please wait while we import students from your LMS.",
+    })
+    await mutation.mutateAsync()
+  }
+
   const mutation = useMutation<void, unknown, void>({
     mutationFn: async () => {
       return defaultMutationFn(`courses/${courseId}/import_students_from_lms/`, undefined, {allowEmptyResponse: true})
@@ -27,17 +36,8 @@ export const useImportStudentsFromLms = () => {
     },
   })
 
-  const importStudentsWithToast = async () => {
-    toast({
-      title: "Importing students",
-      description: "Please wait while we import students from your LMS.",
-    })
-    await mutation.mutateAsync()
-  }
-
-
   return {
-    importStudentsWithToast,
+    importStudentsAsync,
     ...mutation,
   }
 }


### PR DESCRIPTION
### Changes made in this PR:
- On mobile "Import students" and "Import grade book" buttons have been combined into a single "import data" button which when clicked opens up a drop down menu to selected either **Import students** or **Import grade book**.
- On mobile, the navigation buttons in the navbar were overflowing off the screen. To resolve this, a hamburger dropdown menu has been implemented replacing both the account and navigation buttons. With this, the Logout button has been moved to the bottom of this menu instead of being accessible via the account dropdown

### Looks as follows on mobile:
![image](https://github.com/user-attachments/assets/f4367ec9-b5e9-43fd-827d-2e3df4f7c189)
![image](https://github.com/user-attachments/assets/73edf32e-3c59-48a8-8d57-d4a47307e913)

